### PR TITLE
Bumps Solnet deps version and Solnet.Pyth to v5.0.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,6 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.ACCESS_TOKEN }}
-          file: Solnet.Pyth/bin/Release/net5.0/ref/Solnet.Pyth.dll
+          file: artifacts/Solnet.Pyth.dll
           tag: ${{ steps.publish_nuget.outputs.VERSION }}
           upload_url: ${{ steps.create_release.outputs.upload_url }}

--- a/README.md
+++ b/README.md
@@ -3,9 +3,14 @@
 </p>
 <p align="center">
     <a href="https://github.com/bmresearch/Solnet.Pyth/actions/workflows/build.yml">
-       <img alt="Build" src="https://github.com/bmresearch/Solnet.Pyth/actions/workflows/build.yml/badge.svg"></a>
+      <img alt="Build .NET6" src="https://github.com/bmresearch/Solnet.Pyth/actions/workflows/build.yml/badge.svg"></a>
     <a href="https://github.com/bmresearch/Solnet.Pyth/actions/workflows/publish.yml">
-       <img alt="Release" src="https://github.com/bmresearch/Solnet.Pyth/actions/workflows/publish.yml/badge.svg"></a>
+      <img alt="Release .NET6" src="https://github.com/bmresearch/Solnet.Pyth/actions/workflows/publish.yml/badge.svg"></a>
+<br/>
+    <a href="https://github.com/bmresearch/Solnet.Pyth/actions/workflows/build.yml">
+       <img alt="Build .NET5" src="https://github.com/bmresearch/Solnet.Pyth/actions/workflows/build.yml/badge.svg?branch=net5"></a>
+    <a href="https://github.com/bmresearch/Solnet.Pyth/actions/workflows/publish.yml">
+       <img alt="Release .NET5" src="https://github.com/bmresearch/Solnet.Pyth/actions/workflows/publish.yml/badge.svg?branch=net5"></a>
     <a href="https://coveralls.io/github/bmresearch/Solnet.Pyth?branch=main">
         <img src="https://coveralls.io/repos/github/bmresearch/Solnet.Pyth/badge.svg?branch=main" 
             alt="Coverage Status" ></a>

--- a/SharedBuildProperties.props
+++ b/SharedBuildProperties.props
@@ -2,7 +2,7 @@
          xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <Product>Solnet.Pyth</Product>
-        <Version>1.1.1</Version>
+        <Version>5.0.0</Version>
         <Copyright>Copyright 2022 &#169; Solnet</Copyright>
         <Authors>blockmountain</Authors>
         <PublisherName>blockmountain</PublisherName>

--- a/Solnet.Pyth.Examples/Solnet.Pyth.Examples.csproj
+++ b/Solnet.Pyth.Examples/Solnet.Pyth.Examples.csproj
@@ -6,9 +6,9 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="Solnet.Rpc" Version="0.6.1" />
-        <PackageReference Include="Solnet.Wallet" Version="0.6.1" />
-        <PackageReference Include="Solnet.Programs" Version="0.6.1" />
+        <PackageReference Include="Solnet.Rpc" Version="5.0.0" />
+        <PackageReference Include="Solnet.Wallet" Version="5.0.0" />
+        <PackageReference Include="Solnet.Programs" Version="5.0.0" />
     </ItemGroup>
     
     <ItemGroup>

--- a/Solnet.Pyth.Test/Solnet.Pyth.Test.csproj
+++ b/Solnet.Pyth.Test/Solnet.Pyth.Test.csproj
@@ -15,8 +15,8 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="Solnet.Programs" Version="0.6.1" />
-		<PackageReference Include="Solnet.Rpc" Version="0.6.1" />
+		<PackageReference Include="Solnet.Programs" Version="5.0.0" />
+		<PackageReference Include="Solnet.Rpc" Version="5.0.0" />
     </ItemGroup>
 
 	<ItemGroup>

--- a/Solnet.Pyth/Solnet.Pyth.csproj
+++ b/Solnet.Pyth/Solnet.Pyth.csproj
@@ -15,9 +15,9 @@
 	</ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Solnet.Rpc" Version="0.6.1" />
-      <PackageReference Include="Solnet.Wallet" Version="0.6.1" />
-      <PackageReference Include="Solnet.Programs" Version="0.6.1" />
+      <PackageReference Include="Solnet.Rpc" Version="5.0.0" />
+      <PackageReference Include="Solnet.Wallet" Version="5.0.0" />
+      <PackageReference Include="Solnet.Programs" Version="5.0.0" />
     </ItemGroup>
 
     <Import Project="..\SharedBuildProperties.props" />


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready| Versioning/Tooling | No | Closes #20 |

## Problem

Releasing v5.0.0
Turning release pipeline .NET version agnostic by using the packaging from the cake build